### PR TITLE
feat: katib-controller rock

### DIFF
--- a/katib-controller/rockcraft.yaml
+++ b/katib-controller/rockcraft.yaml
@@ -1,0 +1,53 @@
+# Based on https://github.com/kubeflow/katib/blob/v0.15.0/cmd/katib-controller/v1beta1/Dockerfile
+name: katib-controller
+summary: Katib AutoML Controller
+description: |
+  Katib is a Kubernetes-native project for automated machine learning (AutoML). Katib supports Hyperparameter Tuning, Early Stopping and Neural Architecture Search.
+
+  Katib is the project which is agnostic to machine learning (ML) frameworks. It can tune hyperparameters of applications written in any language of the users’ choice and natively supports many ML frameworks, such as TensorFlow, Apache MXNet, PyTorch, XGBoost, and others.
+
+  Katib can perform training jobs using any Kubernetes Custom Resources with out of the box support for Kubeflow Training Operator, Argo Workflows, Tekton Pipelines and many more.
+
+version: v0.15.0_22.04_1
+license: Apache-2.0
+build-base: ubuntu:22.04
+base: bare
+run-user: _daemon_
+services:
+  katib-controller:
+    override: replace
+    summary: "katib-controller service"
+    startup: enabled
+    command: "/katib-controller"
+platforms:
+  amd64:
+
+parts:
+  katib-controller:
+    plugin: go
+    source: https://github.com/kubeflow/katib
+    source-type: git
+    source-tag: v0.15.0
+    build-snaps:
+      - go
+    stage-packages:
+      - libc6_libs
+    build-environment:
+      - CGO_ENABLED: "0"
+      - GOOS: "linux"
+      - GOARCH: "amd64"
+    override-build: |
+      set -xe
+      cd ${CRAFT_PART_SRC}/
+      go mod download all
+      go build -a -o katib-controller ./cmd/katib-controller/v1beta1
+      install -D -m755 katib-controller ${CRAFT_PART_INSTALL}/katib-controller
+
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      # security requirement
+      # there are no packages installed in `bare` base which is used in this rock
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query") \
+       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query


### PR DESCRIPTION
Katib ROCKs are part of main epic for building secure images using ROCKs.
katib-controller ROCK is managed by katib-controller charm. Charm's integration tests should be re-used to test functionality of this ROCK.

Summary of changes:
- Initial version of the ROCK.
- Created rockcraft file for katib-controller ROCK. ROCK is built and limited manual testing is done.