### PR TITLE
Feat earlystopping medianstop rock

### DIFF
--- a/earlystopping-medianstop/rockcraft.yaml
+++ b/earlystopping-medianstop/rockcraft.yaml
@@ -1,65 +1,44 @@
+# https://github.com/kubeflow/katib/tree/master/cmd/earlystopping/medianstop/v1beta1
 name: earlystopping-medianstop
 base: ubuntu:22.04
-version: '1-beta1'
+version: 'v0.12.0_22.04_1'
 summary: Early stopping algorithm for katib.
 description: |
     The median stopping rule stops a pending trial X at step S if the trial’s best 
     objective value by step S is worse than the median value of the running averages 
     of all completed trials' objectives reported up to step S.
 license: GPL-3.0
-platforms:
-    amd64: {}
-    # original dockerfile supports also ppc64le and arm64;
-    # at the moment we only support amd64.
-
+run-user: _daemon_
 services:
-  katib-earlystopping-medianstop:
-    command: /usr/bin/katib-earlystopping-medianstop
+  earlystopping-medianstop:
     override: replace
     startup: enabled
+    command: "python main.py"
+platforms:
+    amd64:
 
 parts:
-    medianstop:
-      plugin: dump
+    earlystopping-medianstop:
+      plugin: python
       source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.12.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/earlystopping/medianstop/v1beta1
+      build-packages:
+        - pip
+        - python3.10
+      stage-packages:
+        - python3.10
+        - python3.10-venv
+      python-requirements:
+        - requirements.txt
       organize:
-        main.py: opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py
-        requirements.txt: opt/katib/cmd/earlystopping/medianstop/v1beta1/requirements.txt
+        pkg: opt/katib/pkg/
+        cmd/earlystopping/medianstop/v1beta1/main.py: opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py
+        cmd/earlystopping/medianstop/v1beta1/requirements.txt: opt/katib/cmd/earlystopping/medianstop/v1beta1/requirements.txt
       stage:
+        - opt/katib/pkg
         - opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py
         - opt/katib/cmd/earlystopping/medianstop/v1beta1/requirements.txt
 
-    medianstop-dependencies:
-      plugin: python
-      source: https://github.com/kubeflow/katib.git
-      source-depth: 1
-      source-subdir: cmd/earlystopping/medianstop/v1beta1
-      source-type: git
-      source-tag: master
-      python-requirements:
-        - requirements.txt
-
-    pkg:
-      plugin: dump
-      source: https://github.com/kubeflow/katib.git
-      source-depth: 1
-      source-type: git
-      source-subdir: pkg
-      organize:
-        '*': opt/katib/pkg/
-      stage:
-        - -opt/katib/pkg/
-
-    entrypoint:
-      plugin: dump
-      source: https://github.com/kubeflow/katib.git
-      source-subdir: cmd/earlystopping/medianstop/v1beta1
-      source-type: git
-      source-tag: master
-      organize:
-        main.py: usr/bin/main.py
-      stage:
-        - usr/bin/main.py

--- a/earlystopping-medianstop/rockcraft.yaml
+++ b/earlystopping-medianstop/rockcraft.yaml
@@ -14,7 +14,8 @@ services:
     override: replace
     summary: "earlystopping-medianstop service"
     startup: enabled
-    command: "python3 /opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py"
+    command: "python3 main.py"
+    working-dir: /opt/katib/cmd/earlystopping/medianstop/v1beta1/
     environment:
       PYTHONPATH: "/usr/local/lib/python3.10/dist-packages/:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python"
 platforms:
@@ -39,8 +40,6 @@ parts:
         - python3.10-venv
       python-requirements:
         - requirements.txt
-      override-build: |
-        craftctl default
 
     # install required contents
     earlystopping-medianstop:

--- a/earlystopping-medianstop/rockcraft.yaml
+++ b/earlystopping-medianstop/rockcraft.yaml
@@ -1,7 +1,7 @@
-# https://github.com/kubeflow/katib/tree/master/cmd/earlystopping/medianstop/v1beta1
+# Based on https://github.com/kubeflow/katib/tree/master/cmd/earlystopping/medianstop/v1beta1
 name: earlystopping-medianstop
 base: ubuntu:22.04
-version: 'v0.12.0_22.04_1'
+version: 'v0.15.0_22.04_1'
 summary: Early stopping algorithm for katib.
 description: |
     The median stopping rule stops a pending trial X at step S if the trial’s best 
@@ -13,32 +13,55 @@ services:
   earlystopping-medianstop:
     override: replace
     startup: enabled
-    command: "python main.py"
+    command: "python3 /opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py"
+    environment:
+      PYTHONPATH: "/usr/local/lib/python3.10/dist-packages/:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python"
 platforms:
     amd64:
 
 parts:
-    earlystopping-medianstop:
+    # install requirements and other dependencies
+    requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.12.0"
+      source-tag: "v0.15.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/earlystopping/medianstop/v1beta1
       build-packages:
-        - pip
+        - python3-pip
         - python3.10
+        - python3.10-venv
+        - python3-dev
       stage-packages:
         - python3.10
         - python3.10-venv
       python-requirements:
         - requirements.txt
+      override-build: |
+        craftctl default
+
+    # install required contents
+    earlystopping-medianstop:
+      plugin: dump
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.15.0"
+      source-depth: 1
+      source-type: git
       organize:
-        pkg: opt/katib/pkg/
+        pkg: opt/katib/pkg
         cmd/earlystopping/medianstop/v1beta1/main.py: opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py
         cmd/earlystopping/medianstop/v1beta1/requirements.txt: opt/katib/cmd/earlystopping/medianstop/v1beta1/requirements.txt
       stage:
         - opt/katib/pkg
         - opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py
         - opt/katib/cmd/earlystopping/medianstop/v1beta1/requirements.txt
+
+    security-team-requirement:
+      plugin: nil
+      override-build: |
+        mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+        (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+         dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+         > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 

--- a/earlystopping-medianstop/rockcraft.yaml
+++ b/earlystopping-medianstop/rockcraft.yaml
@@ -12,6 +12,7 @@ run-user: _daemon_
 services:
   earlystopping-medianstop:
     override: replace
+    summary: "earlystopping-medianstop service"
     startup: enabled
     command: "python3 /opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py"
     environment:


### PR DESCRIPTION
Katib ROCKs are part of main epic for building secure images using ROCKs.

ROCK for Katib earlystopping-medianstop is part of katib-config.

Based on https://github.com/canonical/katib-rocks/pull/1

Summary of changes:
- Updated to use pythong and nil plugins
- Used best practices spec to create rockcraft.yaml
- Tested using manual testing methods.

Since configuration is provided when this container is ran in the pod it is expected to fail when running manually. However, it is enough to ensure that service is being started.

Pebble service:
```
docker run earlystopping-medianstop:v0.15.0_22.04_1 exec pebble restart earlystopping-medianstop
2023-07-18T15:19:59.111Z [pebble] Started daemon.
2023-07-18T15:19:59.127Z [pebble] POST /v1/exec 14.658308ms 202
2023-07-18T15:19:59.142Z [pebble] GET /v1/tasks/1/websocket/control 14.810253ms 200
2023-07-18T15:19:59.142Z [pebble] GET /v1/tasks/1/websocket/stdio 56.173µs 200
2023-07-18T15:19:59.142Z [pebble] GET /v1/tasks/1/websocket/stderr 48.257µs 200
2023-07-18T15:19:59.160Z [pebble] POST /v1/services 14.912263ms 202
2023-07-18T15:19:59.224Z [pebble] Service "earlystopping-medianstop" starting: python3 /opt/katib/cmd/earlystopping/medianstop/v1beta1/main.py
2023-07-18T15:19:59.485Z [earlystopping-medianstop] INFO:root:[Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/namespace'. Service is not running in Kubernetes Pod, "default" namespace is used
```

