### PR TITLE
Feat tfevent-metrics-collector rock

### DIFF
--- a/tfevent-metrics-collector/rockcraft.yaml
+++ b/tfevent-metrics-collector/rockcraft.yaml
@@ -1,0 +1,66 @@
+# Based on https://github.com/kubeflow/katib/blob/master/cmd/metricscollector/v1beta1/tfevent-metricscollector
+name: tfevent-metrics-collector
+base: ubuntu:22.04
+version: 'v0.15.0_22.04_1'
+summary: Metrics collector for TF Events for Katib.
+description: |
+    Collects metrics and stores them on the persistent layer (katib-db-manager). Used as sidecar.
+license: GPL-3.0
+run-user: _daemon_
+services:
+  tfevent-metrics-collector:
+    override: replace
+    summary: "tfevent-metrics-collector service"
+    startup: enabled
+    command: "python3 /opt/katib/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py"
+    environment:
+      PYTHONPATH: "/usr/local/lib/python3.10/dist-packages:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python:/opt/katib/pkg/metricscollector/v1beta1/tfevent-metricscollector:/opt/katib/pkg/metricscollector/v1beta1/common"
+platforms:
+    amd64:
+
+parts:
+    # install requirements and other dependencies
+    requirements-and-deps:
+      plugin: python
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.15.0"
+      source-depth: 1
+      source-type: git
+      source-subdir: cmd/metricscollector/v1beta1/tfevent-metricscollector
+      build-packages:
+        - python3-pip
+        - python3.10
+        - python3.10-venv
+        - python3-dev
+      stage-packages:
+        - python3.10
+        - python3.10-venv
+      python-requirements:
+        - requirements.txt
+      override-build: |
+        craftctl default
+
+    # install required contents
+    tfevent-metrics-collector:
+      plugin: dump
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.15.0"
+      source-depth: 1
+      source-type: git
+      organize:
+        pkg: opt/katib/pkg
+        cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py: opt/katib/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
+        cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt: opt/katib/cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
+      stage:
+        - opt/katib/pkg
+        - opt/katib/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
+        - opt/katib/cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
+
+    security-team-requirement:
+      plugin: nil
+      override-build: |
+        mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+        (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+         dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+         > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+

--- a/tfevent-metrics-collector/rockcraft.yaml
+++ b/tfevent-metrics-collector/rockcraft.yaml
@@ -12,7 +12,8 @@ services:
     override: replace
     summary: "tfevent-metrics-collector service"
     startup: enabled
-    command: "python3 /opt/katib/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py"
+    command: "python3 main.py"
+    working-dir: /opt/katib/cmd/metricscollector/v1beta1/tfevent-metricscollector/
     environment:
       PYTHONPATH: "/usr/local/lib/python3.10/dist-packages:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python:/opt/katib/pkg/metricscollector/v1beta1/tfevent-metricscollector:/opt/katib/pkg/metricscollector/v1beta1/common"
 platforms:
@@ -37,8 +38,6 @@ parts:
         - python3.10-venv
       python-requirements:
         - requirements.txt
-      override-build: |
-        craftctl default
 
     # install required contents
     tfevent-metrics-collector:


### PR DESCRIPTION
Katib ROCKs are part of main epic for building secure images using ROCKs.

ROCK for Katib tfevent-metrics-collector is part of katib-config.
Based on https://github.com/canonical/katib-rocks/pull/7

Since configuration is provided when this container is ran in the pod it is expected to fail when running manually. However, it is enough to ensure that service is being started.

Summary of changes:
- Initial version of TFEvent metrics collector ROCK.
- Updated to use pythong and nil plugins
- Used best practices spec to create rockcraft.yaml
- Tested using manual testing methods.

Pebble service:
```
 docker run tfevent-metrics-collector:v0.15.0_22.04_1 exec pebble restart tfevent-metrics-collector
2023-07-18T16:16:41.967Z [pebble] Started daemon.
2023-07-18T16:16:41.981Z [pebble] POST /v1/exec 13.994567ms 202
2023-07-18T16:16:41.998Z [pebble] GET /v1/tasks/1/websocket/control 16.175359ms 200
2023-07-18T16:16:41.998Z [pebble] GET /v1/tasks/1/websocket/stdio 42.317µs 200
2023-07-18T16:16:41.998Z [pebble] GET /v1/tasks/1/websocket/stderr 30.756µs 200
2023-07-18T16:16:42.016Z [pebble] POST /v1/services 15.734033ms 202
2023-07-18T16:16:42.080Z [pebble] Service "tfevent-metrics-collector" starting: python3 /opt/katib/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
2023-07-18T16:16:42.237Z [tfevent-metrics-collector] 2023-07-18 16:16:42.237567: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX_VNNI FMA
2023-07-18T16:16:42.237Z [tfevent-metrics-collector] To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2023-07-18T16:16:42.313Z [tfevent-metrics-collector] 2023-07-18 16:16:42.313728: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2023-07-18T16:16:42.317Z [tfevent-metrics-collector] 2023-07-18 16:16:42.317084: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
2023-07-18T16:16:42.317Z [tfevent-metrics-collector] 2023-07-18 16:16:42.317100: I tensorflow/compiler/xla/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
2023-07-18T16:16:42.811Z [tfevent-metrics-collector] 2023-07-18 16:16:42.811851: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory
2023-07-18T16:16:42.811Z [tfevent-metrics-collector] 2023-07-18 16:16:42.811902: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory
2023-07-18T16:16:42.811Z [tfevent-metrics-collector] 2023-07-18 16:16:42.811907: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.
2023-07-18T16:16:43.126Z [pebble] GET /v1/changes/1/wait 1.127120069s 200
2023-07-18T16:16:43.139Z [pebble] Stopping all running services.
2023-07-18T16:16:43.179Z [pebble] Service "tfevent-metrics-collector" stopped

```