### PR TITLE
feat: file metrics collector rock

### DIFF
--- a/file-metrics-collector/rockcraft.yaml
+++ b/file-metrics-collector/rockcraft.yaml
@@ -1,0 +1,48 @@
+# Based on https://github.com/kubeflow/katib/blob/v0.15.0/cmd/metricscollector/v1beta1/file-metricscollector
+name: file-metrics-collector
+summary: Metrics collector for file info for Katib.
+description: |
+  Collects metrics from specified file.
+version: v0.15.0_22.04_1
+license: Apache-2.0
+build-base: ubuntu:22.04
+base: bare
+run-user: _daemon_
+services:
+  file-metrics-collector:
+    override: replace
+    summary: "file-metrics-collector service"
+    startup: enabled
+    command: "/app/file-metricscollector"
+platforms:
+  amd64:
+
+parts:
+  file-metrics-collector:
+    plugin: go
+    source: https://github.com/kubeflow/katib
+    source-type: git
+    source-tag: v0.15.0
+    build-snaps:
+      - go
+    stage-packages:
+      - libc6_libs
+    build-environment:
+      - CGO_ENABLED: "0"
+      - GOOS: "linux"
+      - GOARCH: "amd64"
+    override-build: |
+      set -xe
+      mkdir -p ${CRAFT_PART_INSTALL}/app
+      cd ${CRAFT_PART_SRC}/
+      go mod download all
+      go build -a -o file-metricscollector ./cmd/metricscollector/v1beta1/file-metricscollector
+      install -D -m755 file-metricscollector ${CRAFT_PART_INSTALL}/app/file-metricscollector
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      # security requirement
+      # there are no packages installed in `bare` base which is used in this rock
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query") \
+       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query


### PR DESCRIPTION
Katib ROCKs are part of main epic for building secure images using ROCKs.

ROCK for Katib file-metrics-collector is part of katib-config. Based on https://github.com/canonical/katib-rocks/pull/5

Since configuration is provided when this container is ran in the pod it is expected to fail when running manually. However, it is enough to ensure that service is being started.

Summary of changes:
- Initial version of file  metrics collector ROCK.