### PR TITLE
feat: katib-db-manager rock

### DIFF
--- a/katib-db-manager/rockcraft.yaml
+++ b/katib-db-manager/rockcraft.yaml
@@ -1,0 +1,55 @@
+# Based on https://github.com/kubeflow/katib/blob/v0.15.0/cmd/katib-controller/v1beta1/Dockerfile
+name: katib-db-manager
+summary: Katib DB Controller
+description: |
+  Katib database manager.
+version: v0.15.0_22.04_1
+license: Apache-2.0
+build-base: ubuntu:22.04
+base: bare
+run-user: _daemon_
+services:
+  katib-db-manager:
+    override: replace
+    summary: "katib-db-manager service"
+    startup: enabled
+    command: "/app/katib-db-manager"
+platforms:
+  amd64:
+
+parts:
+  katib-db-manager:
+    plugin: go
+    source: https://github.com/kubeflow/katib
+    source-type: git
+    source-tag: v0.15.0
+    build-snaps:
+      - go
+      - curl
+    stage-packages:
+      - libc6_libs
+    build-environment:
+      - CGO_ENABLED: "0"
+      - GOOS: "linux"
+      - GOARCH: "amd64"
+      - GRPC_HEALTH_PROBE_VERSION: "v0.4.15"
+    override-build: |
+      set -xe
+      mkdir -p ${CRAFT_PART_INSTALL}/app
+      cd ${CRAFT_PART_SRC}/
+      go mod download all
+      go build -a -o katib-db-manager ./cmd/db-manager/v1beta1
+      install -D -m755 katib-db-manager ${CRAFT_PART_INSTALL}/app/katib-db-manager
+
+      mkdir -p ${CRAFT_PART_INSTALL}/bin
+      curl -o ${CRAFT_PART_INSTALL}/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${CRAFT_TARGET_ARCH}
+      chmod +x ${CRAFT_PART_INSTALL}/bin/grpc_health_probe
+
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      # security requirement
+      # there are no packages installed in `bare` base which is used in this rock
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query") \
+       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query

--- a/katib-db-manager/rockcraft.yaml
+++ b/katib-db-manager/rockcraft.yaml
@@ -13,7 +13,8 @@ services:
     override: replace
     summary: "katib-db-manager service"
     startup: enabled
-    command: "/app/katib-db-manager"
+    command: "./katib-db-manager"
+    working-dir: /app/
 platforms:
   amd64:
 

--- a/katib-db-manager/rockcraft.yaml
+++ b/katib-db-manager/rockcraft.yaml
@@ -25,14 +25,12 @@ parts:
     source-tag: v0.15.0
     build-snaps:
       - go
-      - curl
     stage-packages:
       - libc6_libs
     build-environment:
       - CGO_ENABLED: "0"
       - GOOS: "linux"
       - GOARCH: "amd64"
-      - GRPC_HEALTH_PROBE_VERSION: "v0.4.15"
     override-build: |
       set -xe
       mkdir -p ${CRAFT_PART_INSTALL}/app
@@ -41,9 +39,16 @@ parts:
       go build -a -o katib-db-manager ./cmd/db-manager/v1beta1
       install -D -m755 katib-db-manager ${CRAFT_PART_INSTALL}/app/katib-db-manager
 
-      mkdir -p ${CRAFT_PART_INSTALL}/bin
-      curl -o ${CRAFT_PART_INSTALL}/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${CRAFT_TARGET_ARCH}
-      chmod +x ${CRAFT_PART_INSTALL}/bin/grpc_health_probe
+  # health check
+  grpc-health-check:
+    plugin: dump
+    source: https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.15/grpc_health_probe-linux-amd64
+    source-type: file
+    organize:
+      grpc_health_probe-linux-amd64: bin/grpc_health_probe
+    override-stage: |
+      craftctl default
+      chmod +x ${CRAFT_STAGE}/bin/grpc_health_probe
 
   security-team-requirement:
     plugin: nil


### PR DESCRIPTION
Katib ROCKs are part of main epic for building secure images using ROCKs. katib-db-manager ROCK is managed by katib-controller charm. Charm's integration tests should be re-used to test functionality of this ROCK.

Summary of changes:
- Initial version of the ROCK.
- Created rockcraft file for katib-db-manager ROCK. ROCK is built and limited manual testing is done.

Manual test:
```
docker run katib-db-manager:v0.15.0_22.04_1 exec /app/katib-db-manager
2023-07-18T18:13:48.097Z [pebble] Started daemon.
2023-07-18T18:13:48.197Z [pebble] POST /v1/exec 98.854491ms 202
2023-07-18T18:13:48.198Z [pebble] GET /v1/tasks/1/websocket/control 152.171µs 200
2023-07-18T18:13:48.199Z [pebble] GET /v1/tasks/1/websocket/stdio 104.532µs 200
2023-07-18T18:13:48.199Z [pebble] GET /v1/tasks/1/websocket/stderr 75.966µs 200
F0718 18:13:48.205851      16 main.go:100] DB_NAME env is not set. Exiting
2023-07-18T18:13:48.315Z [pebble] GET /v1/changes/1/wait 115.753682ms 200
```
