### PR TITLE
feat: add suggestion-hyperband rock

### DIFF
--- a/suggestion-hyperband/rockcraft.yaml
+++ b/suggestion-hyperband/rockcraft.yaml
@@ -1,0 +1,76 @@
+# Based on https://github.com/kubeflow/katib/blob/v0.15.0/cmd/suggestion/hyperband/v1beta1
+name: suggestion-hyperband
+base: ubuntu:22.04
+version: 'v0.15.0_22.04_1'
+summary: "Katib Suggestion Hyperband"
+description: |
+    Katib suggestion Hyperband. Hyperband focuses on early stopping as a strategy for optimizing resource allocation.
+license: GPL-3.0
+run-user: _daemon_
+services:
+  suggestion-hyperband:
+    override: replace
+    summary: "suggestion-hyperband service"
+    startup: enabled
+    command: "python3 main.py"
+    working-dir: /opt/katib/cmd/suggestion/hyperband/v1beta1/
+    environment:
+      PYTHONPATH: "/usr/local/lib/python3.10/dist-packages/:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python:/opt/katib/pkg/apis/manager/health/python"
+platforms:
+    amd64:
+
+parts:
+    # install requirements and other dependencies
+    requirements-and-deps:
+      plugin: python
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.15.0"
+      source-depth: 1
+      source-type: git
+      source-subdir: cmd/suggestion/hyperband/v1beta1
+      build-packages:
+        - python3-pip
+        - python3.10
+        - python3.10-venv
+        - python3-dev
+      stage-packages:
+        - python3.10
+        - python3.10-venv
+      python-requirements:
+        - requirements.txt
+
+    # install required contents
+    suggestion-hyperband:
+      plugin: dump
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.15.0"
+      source-depth: 1
+      source-type: git
+      organize:
+        pkg: opt/katib/pkg
+        cmd/suggestion/hyperband/v1beta1/main.py: opt/katib/cmd/suggestion/hyperband/v1beta1/main.py
+        cmd/suggestion/hyperband/v1beta1/requirements.txt: opt/katib/cmd/suggestion/hyperband/v1beta1/requirements.txt
+      stage:
+        - opt/katib/pkg
+        - opt/katib/cmd/suggestion/hyperband/v1beta1/main.py
+        - opt/katib/cmd/suggestion/hyperband/v1beta1/requirements.txt
+
+    # health check
+    grpc-health-check:
+      plugin: dump
+      source: https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.15/grpc_health_probe-linux-amd64
+      source-type: file
+      organize:
+        grpc_health_probe-linux-amd64: bin/grpc_health_probe
+      override-stage: |
+        craftctl default
+        chmod +x ${CRAFT_STAGE}/bin/grpc_health_probe
+
+    security-team-requirement:
+      plugin: nil
+      override-build: |
+        mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+        (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+         dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+         > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+


### PR DESCRIPTION
Details are in #17

Katib ROCKs are part of main epic for building secure images using ROCKs.

ROCK for Katib suggestion-hyperband is part of katib-config.

## Summary of changes:

Initial version of suggestion-hyperband ROCK.
Manual test:
```
sudo docker run suggestion-hyperband_v0.15.0_22.04_1_amd64:rock exec bash -c 'export PYTHONPATH="/usr/local/lib/python3.10/dist-packages
/:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python:/opt/katib/pkg/apis/manager/health/python" && python3 /opt/katib/cmd/suggestion/hyperband/v1beta1/main.py'
2023-08-17T14:04:05.447Z [pebble] Started daemon.
2023-08-17T14:04:05.454Z [pebble] POST /v1/exec 6.412998ms 202
2023-08-17T14:04:05.460Z [pebble] GET /v1/tasks/1/websocket/control 4.956321ms 200
2023-08-17T14:04:05.462Z [pebble] GET /v1/tasks/1/websocket/stdio 140.314µs 200
2023-08-17T14:04:05.462Z [pebble] GET /v1/tasks/1/websocket/stderr 94.174µs 200
```

Pebble service
```
sudo docker run suggestion-hyperband_v0.15.0_22.04_1_amd64:rock exec pebble restart suggestion-hyperband
2023-08-17T14:05:30.318Z [pebble] Started daemon.
2023-08-17T14:05:30.333Z [pebble] POST /v1/exec 10.327759ms 202
2023-08-17T14:05:30.340Z [pebble] GET /v1/tasks/1/websocket/control 5.979179ms 200
2023-08-17T14:05:30.342Z [pebble] GET /v1/tasks/1/websocket/stdio 325.425µs 200
2023-08-17T14:05:30.346Z [pebble] GET /v1/tasks/1/websocket/stderr 136.33µs 200
2023-08-17T14:05:30.372Z [pebble] POST /v1/services 9.917429ms 202
2023-08-17T14:05:30Z INFO Service "suggestion-hyperband" has never been started.
2023-08-17T14:05:30.423Z [pebble] Service "suggestion-hyperband" starting: python3 main.py
2023-08-17T14:05:31.522Z [pebble] GET /v1/changes/1/wait 1.175234107s 200
2023-08-17T14:05:31.532Z [pebble] Stopping all running services.
2023-08-17T14:05:31.556Z [pebble] Service "suggestion-hyperband" stopped
```