### PR TITLE
feat: updated cert-manager rock

### DIFF
--- a/cert-generator/rockcraft.yaml
+++ b/cert-generator/rockcraft.yaml
@@ -1,17 +1,19 @@
+# Based on https://github.com/kubeflow/katib/blob/release-0.15/cmd/cert-generator/v1beta1/Dockerfile
 name: cert-generator
-summary: Katib cert generator in a ROCK.
+summary: Certificate generator for Katib standalone installation.
 description: "Katib cert generator"
-version: "0.15.0"
+version: "v0.15.0_22.04_1"
+license: Apache-2.0
 base: ubuntu:22.04
 build-base: ubuntu:22.04
-license: Apache-2.0
-
+run-user: _daemon_
 services:
   cert-generator:
-    command: /app/katib-cert-generator
     override: replace
+    summary: "Cert genrator service"
     startup: enabled
-
+    command: katib-cert-generator
+    working-dir: /app
 platforms:
   amd64:
 
@@ -28,3 +30,11 @@ parts:
       CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o katib-cert-generator ./cmd/cert-generator/v1beta1
       mkdir -p ${CRAFT_PART_INSTALL}/app/
       cp -rp katib-cert-generator ${CRAFT_PART_INSTALL}/app/
+
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+        > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query


### PR DESCRIPTION
Details are in #17

Katib ROCKs are part of main epic for building secure images using ROCKs.
Initial cert-manager ROCK was created during workshop. This PR is to updated it to bring it up to spec with best practices.

ROCK for Katib scert-manager is part of katib-config.

Summary of changes:

## Summary of changes:
- Added security team requirement.
- Added non-root user setup.

Manual test:
```
$ docker run -it cert-generator_v0.15.0_22.04_1:v0.15.0_22.04_1
2023-08-17T15:21:33.124Z [pebble] Started daemon.
2023-08-17T15:21:33.138Z [pebble] POST /v1/services 11.771457ms 202
2023-08-17T15:21:33.138Z [pebble] Started default services with change 1.
2023-08-17T15:21:33.145Z [pebble] Service "cert-generator" starting: /app/katib-cert-generator
```

Pebble service
```
$ docker run cert-generator_v0.15.0_22.04_1:v0.15.0_22.04_1 exec pebble restart cert-generator
2023-08-17T14:57:44.686Z [pebble] Started daemon.
2023-08-17T14:57:44.694Z [pebble] POST /v1/exec 8.108973ms 202
2023-08-17T14:57:44.702Z [pebble] GET /v1/tasks/1/websocket/control 7.430071ms 200
2023-08-17T14:57:44.702Z [pebble] GET /v1/tasks/1/websocket/stdio 25.203µs 200
2023-08-17T14:57:44.702Z [pebble] GET /v1/tasks/1/websocket/stderr 27.241µs 200
2023-08-17T14:57:44.712Z [pebble] POST /v1/services 7.999054ms 202
2023-08-17T14:57:44Z INFO Service "cert-generator" has never been started.
2023-08-17T14:57:44.742Z [pebble] Service "cert-generator" starting: /app/katib-cert-generator
error: cannot perform the following tasks:
- Start service "cert-generator" (cannot start service: exited quickly with code 1)
2023-08-17T14:57:44.846Z [pebble] GET /v1/changes/1/wait 143.777605ms 200
```
