### PR TITLE
feat: add suggestion-nas-darts rockcraft project

### DIFF
--- a/suggestion-nas-darts/rockcraft.yaml
+++ b/suggestion-nas-darts/rockcraft.yaml
@@ -1,0 +1,64 @@
+# Based on https://github.com/kubeflow/katib/blob/v0.16.0/cmd/suggestion/nas/darts/v1beta1
+name: suggestion-nas-darts
+base: ubuntu:22.04
+version: 'v0.16.0_22.04_1'
+summary: "Katib Suggestion NAS DARTS"
+description: |
+      Katib Differentiable Architecture Search implementation.
+license: GPL-3.0
+run-user: _daemon_
+services:
+  suggestion-nas-darts:
+    override: replace
+    summary: "suggestion-nas-darts service"
+    startup: enabled
+    command: "python3 main.py"
+    working-dir: /opt/katib/cmd/suggestion/nas/darts/v1beta1
+    environment:
+      PYTHONPATH: "/usr/local/lib/python3.10/dist-packages/:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python:/opt/katib/pkg/apis/manager/health/python"
+platforms:
+    amd64:
+
+parts:
+    # install requirements and other dependencies
+    requirements-and-deps:
+      plugin: python
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.16.0"
+      source-depth: 1
+      source-type: git
+      source-subdir: cmd/suggestion/nas/darts/v1beta1
+      build-packages:
+        - python3-pip
+        - python3.10
+        - python3.10-venv
+        - python3-dev
+      stage-packages:
+        - python3.10
+        - python3.10-venv
+      python-requirements:
+        - requirements.txt
+
+    # install required contents
+    suggestion-nas-darts:
+      plugin: dump
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.16.0"
+      source-depth: 1
+      source-type: git
+      organize:
+        pkg: opt/katib/pkg
+        cmd/suggestion/nas/darts/v1beta1/main.py: opt/katib/cmd/suggestion/nas/darts/v1beta1/main.py
+        cmd/suggestion/nas/darts/v1beta1/requirements.txt: opt/katib/cmd/suggestion/nas/darts/v1beta1/requirements.txt
+      stage:
+        - opt/katib/pkg
+        - opt/katib/cmd/suggestion/nas/darts/v1beta1/main.py
+        - opt/katib/cmd/suggestion/nas/darts/v1beta1/requirements.txt
+
+    security-team-requirement:
+      plugin: nil
+      override-build: |
+        mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+        (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+         dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+         > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query


### PR DESCRIPTION
Part of #17

Details are in https://github.com/canonical/katib-rocks/issues/17
base on #9 

Katib ROCKs are part of main epic for building secure images using ROCKs.

ROCK for Katib suggestion-nas-darts is part of katib-config.

## Summary of changes:

Initial version of suggestion-nas-darts ROCK.
Manual test:
```
sudo docker run --rm suggestion-nas-darts:rock exec bash -c 'export PYTHONPATH="/usr/local/lib/python3.10/dist-packages/:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python:/opt/katib/pkg/apis/manager/health/python" && python3 /opt/katib/cmd/suggestion/nas/darts/v1beta1/main.py'
```

Pebble service
```
sudo docker run --rm suggestion-nas-darts:rock exec pebble restart suggestion-nas-darts
```