### PR TITLE
feat: add suggestion-nas-enas rock

### DIFF
--- a/suggestion-enas/rockcraft.yaml
+++ b/suggestion-enas/rockcraft.yaml
@@ -1,0 +1,64 @@
+# Based on https://github.com/kubeflow/katib/blob/v0.16.0/cmd/suggestion/nas/enas/v1beta1
+name: suggestion-enas
+base: ubuntu:22.04
+version: 'v0.16.0_22.04_1'
+summary: "Katib Suggestion enas"
+description: |
+    
+license: GPL-3.0
+run-user: _daemon_
+services:
+  suggestion-enas:
+    override: replace
+    summary: "suggestion-enas service"
+    startup: enabled
+    command: "python3 main.py"
+    working-dir: /opt/katib/cmd/suggestion/nas/enas/v1beta1/
+    environment:
+      PYTHONPATH: "/usr/local/lib/python3.10/dist-packages/:/opt/katib:/opt/katib/pkg/apis/manager/v1beta1/python:/opt/katib/pkg/apis/manager/health/python"
+platforms:
+    amd64:
+
+parts:
+    # install requirements and other dependencies
+    requirements-and-deps:
+      plugin: python
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.16.0"
+      source-depth: 1
+      source-type: git
+      source-subdir: cmd/suggestion/nas/enas/v1beta1
+      build-packages:
+        - python3-pip
+        - python3.10
+        - python3.10-venv
+        - python3-dev
+      stage-packages:
+        - python3.10
+        - python3.10-venv
+      python-requirements:
+        - requirements.txt
+
+    # install required contents
+    suggestion-enas:
+      plugin: dump
+      source: https://github.com/kubeflow/katib.git
+      source-tag: "v0.16.0"
+      source-depth: 1
+      source-type: git
+      organize:
+        pkg: opt/katib/pkg
+        cmd/suggestion/nas/enas/v1beta1/main.py: opt/katib/cmd/suggestion/nas/enas/v1beta1/main.py
+        cmd/suggestion/nas/enas/v1beta1/requirements.txt: opt/katib/cmd/suggestion/nas/enas/v1beta1/requirements.txt
+      stage:
+        - opt/katib/pkg
+        - opt/katib/cmd/suggestion/nas/enas/v1beta1/main.py
+        - opt/katib/cmd/suggestion/nas/enas/v1beta1/requirements.txt
+
+    security-team-requirement:
+      plugin: nil
+      override-build: |
+        mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+        (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+         dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+         > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query


### PR DESCRIPTION
Details are in #17

Katib ROCKs are part of main epic for building secure images using ROCKs.

ROCK for Katib suggestion-enas is part of katib-config.

## Summary of changes:

Initial version of suggestion-enas ROCK.

**Note:** no need to keep GRPC binary from v0.15.0, since this type of ROCK images are not managed by charms.
GRPC checks will be peformed by K8S on this images.