### PR TITLE
feat: add suggestion goptuna rock

### DIFF
--- a/suggestion-goptuna/rockcraft.yaml
+++ b/suggestion-goptuna/rockcraft.yaml
@@ -32,7 +32,7 @@ parts:
       cd /go/src/github.com/kubeflow/katib/ && go mod download -x
       cp -r ${CRAFT_PART_SRC}/cmd ./cmd
       cp -r ${CRAFT_PART_SRC}/pkg ./pkg
-      CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o goptuna-suggestion ./cmd/suggestion/goptuna/v1beta1
+      CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o goptuna-suggestion ./cmd/suggestion/goptuna/v1beta1
       mkdir -p ${CRAFT_PART_INSTALL}/opt/katib
       cp /go/src/github.com/kubeflow/katib/goptuna-suggestion ${CRAFT_PART_INSTALL}/opt/katib
       chgrp -R 0 ${CRAFT_PART_INSTALL}/opt/katib && chmod -R g+rwX ${CRAFT_PART_INSTALL}/opt/katib

--- a/suggestion-goptuna/rockcraft.yaml
+++ b/suggestion-goptuna/rockcraft.yaml
@@ -1,0 +1,44 @@
+# Based on https://github.com/kubeflow/katib/blob/release-0.16/cmd/suggestion/goptuna/v1beta1/Dockerfile
+name: suggestion-goptuna
+summary: Decentralized hyperparameter optimization framework, inspired by Optuna implemented in pure Go
+description: "Katib suggestion goptuna"
+version: "v0.16.0_22.04_1"
+license: Apache-2.0
+base: ubuntu:22.04
+build-base: ubuntu:22.04
+run-user: _daemon_
+services:
+  suggestion-goptuna:
+    override: replace
+    summary: "Katib suggestion goptuna"
+    startup: enabled
+    command: ./goptuna-suggestion
+    working-dir: /opt/katib
+platforms:
+  amd64:
+
+parts:
+  suggestion-goptuna:
+    plugin: go
+    source: https://github.com/kubeflow/katib
+    source-type: git
+    source-tag: "v0.16.0"
+    build-snaps:
+      - go/1.21/stable
+    working-dir: /go/src/github.com/kubeflow/katib
+    override-build: |
+      go.mod .
+      go.sum .
+      go mod download -x
+      CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o goptuna-suggestion ./cmd/suggestion/goptuna/v1beta1
+      mkdir -p ${CRAFT_PART_INSTALL}/opt/katib
+      cp /go/src/github.com/kubeflow/katib/goptuna-suggestion ${CRAFT_PART_INSTALL}/opt/katib
+      chgrp -R 0 ${CRAFT_PART_INSTALL}/opt/katib && chmod -R g+rwX ${CRAFT_PART_INSTALL}/opt/katib
+
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+        > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query

--- a/suggestion-goptuna/rockcraft.yaml
+++ b/suggestion-goptuna/rockcraft.yaml
@@ -22,14 +22,16 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: "v0.16.0"
+    source-tag: "v0.16.0-rc.1"
     build-snaps:
       - go/1.21/stable
-    working-dir: /go/src/github.com/kubeflow/katib
     override-build: |
-      go.mod .
-      go.sum .
-      go mod download -x
+      mkdir -p /go/src/github.com/kubeflow/katib/
+      cp go.mod /go/src/github.com/kubeflow/katib/
+      cp go.sum /go/src/github.com/kubeflow/katib/
+      cd /go/src/github.com/kubeflow/katib/ && go mod download -x
+      cp -r ${CRAFT_PART_SRC}/cmd ./cmd
+      cp -r ${CRAFT_PART_SRC}/pkg ./pkg
       CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o goptuna-suggestion ./cmd/suggestion/goptuna/v1beta1
       mkdir -p ${CRAFT_PART_INSTALL}/opt/katib
       cp /go/src/github.com/kubeflow/katib/goptuna-suggestion ${CRAFT_PART_INSTALL}/opt/katib


### PR DESCRIPTION
Part of #17

Details are in https://github.com/canonical/katib-rocks/issues/17
base on #9 

Katib ROCKs are part of main epic for building secure images using ROCKs.

ROCK for Katib suggestion-goptuna is part of katib-config.

## Summary of changes:

Initial version of suggestion-goptuna ROCK.
Manual test:
```
sudo docker run --rm suggestion-goptuna:rock exec bash -c './goptuna-suggestion'
```

Pebble service
```
sudo docker run --rm suggestion-goptuna:rock exec pebble restart suggestion-goptuna
```