### PR TITLE
fix: fix git tag for suggestion-nas-darts

### DIFF
--- a/suggestion-nas-darts/rockcraft.yaml
+++ b/suggestion-nas-darts/rockcraft.yaml
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.16.0"
+      source-tag: "v0.16.0-rc.1"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/nas/darts/v1beta1
@@ -43,7 +43,7 @@ parts:
     suggestion-nas-darts:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.16.0"
+      source-tag: "v0.16.0-rc.1"
       source-depth: 1
       source-type: git
       organize:


### PR DESCRIPTION
The tag that was in the rockcraft project did not match any of the upstream tags, preventing the rock to be built. Adding the correct tag.