### PR TITLE
update katib-ui rockcraft.yaml

### DIFF
--- a/katib-ui-rock/rockcraft.yaml
+++ b/katib-ui-rock/rockcraft.yaml
@@ -99,3 +99,12 @@ parts:
     override-prime: |
       mkdir -p $CRAFT_PRIME/app
       cp $CRAFT_PART_BUILD/katib-ui $CRAFT_PRIME/app
+
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      # security requirement
+      # there are no packages installed in `bare` base which is used in this rock
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query") \
+       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query

--- a/katib-ui-rock/rockcraft.yaml
+++ b/katib-ui-rock/rockcraft.yaml
@@ -62,8 +62,8 @@ parts:
       # Pull only the files we need for the build from src
       cp $CRAFT_PART_SRC/pkg/ui/v1beta1/frontend/package*.json ./
       npm ci
-      cp -r $CRAFT_STAGE/frontend-lib/dist/kubeflow ./node_modules/kubeflow
       cp -r $CRAFT_PART_SRC/pkg/ui/v1beta1/frontend/* .
+      cp -r $CRAFT_STAGE/frontend-lib/dist/kubeflow ./node_modules/kubeflow
       npm run build:prod
 
     override-prime: |

--- a/katib-ui-rock/rockcraft.yaml
+++ b/katib-ui-rock/rockcraft.yaml
@@ -3,9 +3,7 @@ name: katib-ui
 summary: Katib UI
 description: |
   Katib UI.
-# TODO: set version
-# version: v0.15.0_22.04_1
-version: todo
+version: v0.16.0
 license: Apache-2.0
 build-base: ubuntu@22.04
 base: bare

--- a/katib-ui-rock/rockcraft.yaml
+++ b/katib-ui-rock/rockcraft.yaml
@@ -1,11 +1,13 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.15.0/cmd/ui/v1beta1
+# Based on https://github.com/kubeflow/katib/blob/v0.16.0/cmd/ui/v1beta1/Dockerfile
 name: katib-ui
 summary: Katib UI
 description: |
   Katib UI.
-version: v0.15.0_22.04_1
+# TODO: set version
+# version: v0.15.0_22.04_1
+version: todo
 license: Apache-2.0
-build-base: ubuntu:22.04
+build-base: ubuntu@22.04
 base: bare
 run-user: _daemon_
 services:
@@ -19,42 +21,83 @@ platforms:
   amd64:
 
 parts:
-  katib-ui:
+  frontend-lib:
+    plugin: nil
+    source: https://github.com/kubeflow/kubeflow
+    source-type: git
+    # Set source-tag here to the commit cited in https://github.com/kubeflow/katib/blob/master/pkg/ui/v1beta1/frontend/COMMIT
+    # for this Katib release
+    # Note: Katib 0.16.0 cannot build with Kubeflow v1.8-branch because Kubeflow refactored this lib
+    source-commit: 046c6d3c8301a95a2809c0d927bbbf72638dd639
+    # Omit source-depth because we're cloning a commit
+    # source-depth: 1
+    build-environment:
+      # suppress analytics collection
+      - NG_CLI_ANALYTICS: false
+    build-snaps:
+      - node/12/stable
+    override-build: |
+      # Clean the build dir so we don't accidentally use files we didn't intend
+      rm -rf ./*
+
+      # Pull only the files we need for the build from src, and build
+      cp $CRAFT_PART_SRC/components/crud-web-apps/common/frontend/kubeflow-common-lib/package*.json ./
+      npm ci
+      cp -r $CRAFT_PART_SRC/components/crud-web-apps/common/frontend/kubeflow-common-lib/* ./
+      npm run build
+      
+    override-stage: |
+      mkdir -p $CRAFT_STAGE/frontend-lib/dist
+      cp -r $CRAFT_PART_BUILD/dist/kubeflow $CRAFT_STAGE/frontend-lib/dist/kubeflow
+
+  frontend:
+    after: [frontend-lib]
+    plugin: nil
+    source: https://github.com/kubeflow/katib
+    source-type: git
+    source-tag: v0.16.0
+    source-depth: 1
+    build-snaps:
+      - node/12/stable
+    override-build: |
+      # Clean the build dir so we don't accidentally use files we didn't intend
+      rm -rf ./*
+
+      # Pull only the files we need for the build from src
+      cp $CRAFT_PART_SRC/pkg/ui/v1beta1/frontend/package*.json ./
+      npm ci
+      cp -r $CRAFT_STAGE/frontend-lib/dist/kubeflow ./node_modules/kubeflow
+      cp -r $CRAFT_PART_SRC/pkg/ui/v1beta1/frontend/* .
+      npm run build:prod
+
+    override-prime: |
+      mkdir -p $CRAFT_PRIME/app/build
+      cp -r $CRAFT_PART_BUILD/dist/static $CRAFT_PRIME/app/build/static
+
+  backend:
     plugin: go
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: v0.15.0
+    source-tag: v0.16.0
     build-snaps:
-      - go
-      - curl
-    build-packages:
-      - npm
-    stage-packages:
-      - libc6_libs
+      - go/1.20/stable
     build-environment:
-      - CGO_ENABLED: "0"
-      - GOOS: "linux"
-      - GOARCH: "amd64"
+      - CGO_ENABLED: 0
+      - GOOS: linux
     override-build: |
-      set -xe
+      # Clean the build dir so we don't accidentally use files we didn't intend
+      rm -rf ./*
+      
+      # Pull only the files we need for the build from src
+      cp -r $CRAFT_PART_SRC/go.mod ./
+      cp -r $CRAFT_PART_SRC/go.sum ./
+      go mod download -x
+      cp -r $CRAFT_PART_SRC/cmd ./cmd
+      cp -r $CRAFT_PART_SRC/pkg ./pkg
 
-      cp -r ${CRAFT_PART_SRC}/pkg/ui/v1beta1/frontend .
-      cd ./frontend && rm -rf package-lock.json && npm install && npm ci && npm run build && cd ..
-      rm -rf ./frontend/node_modules
-      mkdir -p ${CRAFT_PART_INSTALL}/app/build
-      cp -r ./frontend/build/* ${CRAFT_PART_INSTALL}/app/build
-
-      mkdir -p ${CRAFT_PART_INSTALL}/app
-      cd ${CRAFT_PART_SRC}/
-      go mod download all
+      # Build
       go build -a -o katib-ui ./cmd/ui/v1beta1
-      install -D -m755 katib-ui ${CRAFT_PART_INSTALL}/app/katib-ui
 
-  security-team-requirement:
-    plugin: nil
-    override-build: |
-      # security requirement
-      # there are no packages installed in `bare` base which is used in this rock
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query") \
-       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+    override-prime: |
+      mkdir -p $CRAFT_PRIME/app
+      cp $CRAFT_PART_BUILD/katib-ui $CRAFT_PRIME/app

--- a/katib-ui-rock/rockcraft.yaml
+++ b/katib-ui-rock/rockcraft.yaml
@@ -23,12 +23,10 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    # Set source-tag here to the commit cited in https://github.com/kubeflow/katib/blob/master/pkg/ui/v1beta1/frontend/COMMIT
+    # Set source-commit here to the commit cited in 
+    # https://github.com/kubeflow/katib/blob/master/pkg/ui/v1beta1/frontend/COMMIT
     # for this Katib release
-    # Note: Katib 0.16.0 cannot build with Kubeflow v1.8-branch because Kubeflow refactored this lib
     source-commit: 046c6d3c8301a95a2809c0d927bbbf72638dd639
-    # Omit source-depth because we're cloning a commit
-    # source-depth: 1
     build-environment:
       # suppress analytics collection
       - NG_CLI_ANALYTICS: false
@@ -78,7 +76,9 @@ parts:
     source-type: git
     source-tag: v0.16.0
     build-snaps:
-      - go/1.20/stable
+      # Use go version that satisfies requirements in
+      # https://github.com/kubeflow/katib/blob/v0.16.0/docs/developer-guide.md#requirements
+      - go/1.21/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux


### PR DESCRIPTION
Previously, an older version of the katib-ui had been rocked.  This commit updates the rock to the current katib-ui, replicating the build defined by https://github.com/kubeflow/katib/blob/v0.16.0/cmd/ui/v1beta1/Dockerfile

Note:
* the version of the frontend-lib pulled here is that specified by the katib repo in the [COMMIT](https://github.com/kubeflow/katib/blob/v0.16.0/pkg/ui/v1beta1/frontend/COMMIT) file of the upstream repo
* the GOARCH is omitted from building here because upstream also omits this.  This might be something to revisit later, or might be something determined in different ways in rocks anyway?

Closes #32 

#### Testing instructions

Do:
```bash
VERSION=version_in_rockcraft_file
rockcraft pack
skopeo --insecure-policy copy oci-archive:katib-ui_${VERSION}_amd64.rock docker-daemon:katib-ui:${VERSION}
docker save katib-ui:${VERSION} > katib_ui_${VERSION}.tar
microk8s ctr image import katib_ui_${VERSION}.tar
```
Then do:
* `juju deploy katib-ui --resource oci-image=katib-ui:${VERSION}` using a charm version includes [this fix to the katib-ui charm](https://github.com/canonical/katib-operators/pull/160)
* browse to `KATIB_UI_SERVICE_IP:8080/katib/` and you should see the katib UI