### PR TITLE
chore: replace ROCKs with rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # katib-rocks
-ROCKs for Kubeflow Katib
+rocks for Kubeflow Katib

--- a/earlystopping-medianstop/README.md
+++ b/earlystopping-medianstop/README.md
@@ -1,2 +1,2 @@
 # earlystopping-medianstop
-ROCK for Kubeflow Katib earlystopping-medianstop
+rock for Kubeflow Katib earlystopping-medianstop


### PR DESCRIPTION
This commit replaces ROCKs with rocks to be in sync with Canonical's standard terminology.

Part of canonical/bundle-kubeflow#916