### PR TITLE
Fix permission in suggestion-enas

### DIFF
--- a/suggestion-enas/rockcraft.yaml
+++ b/suggestion-enas/rockcraft.yaml
@@ -39,21 +39,22 @@ parts:
       python-requirements:
         - requirements.txt
 
-    # install required contents
     suggestion-enas:
-      plugin: dump
+      plugin: nil
       source: https://github.com/kubeflow/katib.git
       source-tag: "v0.17.0"
       source-depth: 1
       source-type: git
-      organize:
-        pkg: opt/katib/pkg
-        cmd/suggestion/nas/enas/v1beta1/main.py: opt/katib/cmd/suggestion/nas/enas/v1beta1/main.py
-        cmd/suggestion/nas/enas/v1beta1/requirements.txt: opt/katib/cmd/suggestion/nas/enas/v1beta1/requirements.txt
-      stage:
-        - opt/katib/pkg
-        - opt/katib/cmd/suggestion/nas/enas/v1beta1/main.py
-        - opt/katib/cmd/suggestion/nas/enas/v1beta1/requirements.txt
+      override-build: |
+        # Move files to dedicated location
+        mkdir -p ${CRAFT_PART_INSTALL}/opt/katib/pkg
+        mkdir -p ${CRAFT_PART_INSTALL}/opt/katib/cmd/suggestion/nas/enas/v1beta1
+        cp -r pkg/* ${CRAFT_PART_INSTALL}/opt/katib/pkg
+        cp -r cmd/suggestion/nas/enas/v1beta1/* ${CRAFT_PART_INSTALL}/opt/katib/cmd/suggestion/nas/enas/v1beta1
+
+        # Change permissions on the folder for the _daemon_ user
+        chown -R 584792:584792 ${CRAFT_PART_INSTALL}/opt/katib/cmd/suggestion/nas/enas/v1beta1
+        chmod -R 755 ${CRAFT_PART_INSTALL}/opt/katib/cmd/suggestion/nas/enas/v1beta1
 
     security-team-requirement:
       plugin: nil


### PR DESCRIPTION
Closes: https://github.com/canonical/katib-rocks/issues/50

Add correct permissions for the user in the rock.

How to test:
```
cd suggestion-enas
rockcraft clean && rockcraft pack --verbosity=trace --debug 
sudo rockcraft.skopeo --insecure-policy copy oci-archive:suggestion-enas_v0.17.0_amd64.rock docker-daemon:misohu/suggestion-enas:0.17.0
docker run -ti  misohu/suggestion-enas:0.17.0 -v
```

expected output 
```
2024-09-03T13:24:25.749Z [pebble] Started daemon.
2024-09-03T13:24:25.784Z [pebble] POST /v1/services 16.991767ms 202
2024-09-03T13:24:25.800Z [pebble] Service "suggestion-enas" starting: python3 main.py
2024-09-03T13:24:26.093Z [suggestion-enas] 2024-09-03 13:24:26.093490: I tensorflow/core/util/port.cc:113] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2024-09-03T13:24:26.093Z [suggestion-enas] 2024-09-03 13:24:26.093835: I external/local_tsl/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.
2024-09-03T13:24:26.095Z [suggestion-enas] 2024-09-03 13:24:26.095833: I external/local_tsl/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.
2024-09-03T13:24:26.122Z [suggestion-enas] 2024-09-03 13:24:26.122534: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
2024-09-03T13:24:26.122Z [suggestion-enas] To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2024-09-03T13:24:26.553Z [suggestion-enas] 2024-09-03 13:24:26.553603: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
2024-09-03T13:24:26.827Z [pebble] GET /v1/changes/1/wait 1.042654734s 200
2024-09-03T13:24:26.827Z [pebble] Started default services with change 1.
^C2024-09-03T13:24:34.474Z [pebble] Exiting on interrupt signal.
2024-09-03T13:24:34.498Z [pebble] Stopping all running services.
2024-09-03T13:24:34.543Z [pebble] Service "suggestion-enas" stopped
```

no permission denied.

I have also tested locally with katib-operator experiment. No problems there.