### PR TITLE
fix: remove incorrect report-vulnerabilities input from scan_images workflow

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -16,6 +16,5 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
-      report-vulnerabilities: true
       severity: "HIGH,CRITICAL"
       branch: ${{ matrix.branch }}


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#1118