### PR TITLE
chore: update suggestion-enas rock to v0.18.0-rc.0

### DIFF
--- a/suggestion-enas/rockcraft.yaml
+++ b/suggestion-enas/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.17.0/cmd/suggestion/nas/enas/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/nas/enas/v1beta1/Dockerfile
 name: suggestion-enas
 base: ubuntu@22.04
 version: 'v0.18.0-rc.0'

--- a/suggestion-enas/rockcraft.yaml
+++ b/suggestion-enas/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Based on https://github.com/kubeflow/katib/blob/v0.17.0/cmd/suggestion/nas/enas/v1beta1/Dockerfile
 name: suggestion-enas
 base: ubuntu@22.04
-version: 'v0.17.0'
+version: 'v0.18.0-rc.0'
 summary: "Katib Suggestion enas"
 description: |
     
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.17.0"
+      source-tag: "v0.18.0-rc.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/nas/enas/v1beta1
@@ -42,7 +42,7 @@ parts:
     suggestion-enas:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.17.0"
+      source-tag: "v0.18.0-rc.0"
       source-depth: 1
       source-type: git
       organize:

--- a/suggestion-enas/tox.ini
+++ b/suggestion-enas/tox.ini
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # export rock to docker
@@ -31,7 +31,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Based on: https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/nas/enas/v1beta1/Dockerfile.

Note that there weren't any changes.