### PR TITLE
chore: update hyperband rock to v0.18.0-rc.0

### DIFF
--- a/suggestion-hyperband/rockcraft.yaml
+++ b/suggestion-hyperband/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.17.0/cmd/suggestion/hyperband/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/hyperband/v1beta1/Dockerfile
 name: suggestion-hyperband
 base: ubuntu@22.04
-version: 'v0.17.0'
+version: 'v0.18.0-rc.0'
 summary: "Katib Suggestion Hyperband"
 description: |
     Katib suggestion Hyperband. Hyperband focuses on early stopping as a strategy for optimizing resource allocation.
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.17.0"
+      source-tag: "v0.18.0-rc.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/hyperband/v1beta1
@@ -43,7 +43,7 @@ parts:
     suggestion-hyperband:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.17.0"
+      source-tag: "v0.18.0-rc.0"
       source-depth: 1
       source-type: git
       organize:

--- a/suggestion-hyperband/tox.ini
+++ b/suggestion-hyperband/tox.ini
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # export rock to docker
@@ -31,7 +31,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Based on the upstream file: https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/hyperband/v1beta1/Dockerfile