### PR TITLE
chore: bump source and version of the rock 0.17 -> 0.18

### DIFF
--- a/katib-db-manager/rockcraft.yaml
+++ b/katib-db-manager/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.17.0/cmd/db-manager/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/db-manager/v1beta1/Dockerfile
 name: katib-db-manager
 summary: Katib DB Controller
 description: |
   Katib database manager.
-version: v0.17.0
+version: v0.18.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -22,7 +22,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: v0.17.0
+    source-tag: v0.18.0-rc.0
     build-snaps:
       - go
     stage-packages:

--- a/katib-db-manager/rockcraft.yaml
+++ b/katib-db-manager/rockcraft.yaml
@@ -3,7 +3,7 @@ name: katib-db-manager
 summary: Katib DB Controller
 description: |
   Katib database manager.
-version: v0.18.0
+version: v0.18.0-rc.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_


### PR DESCRIPTION
Bump the rock 0.17 -> 0.18.0-rc.0 in preparation for a new release.

Please note that there haven't been updates to the upstream Dockerfile of this rock, therefore this PR only bumps the version and source to keep it up to date with the versioning system.