### PR TITLE
chore: update file metrics rock to 0.18.0-rc.0

### DIFF
--- a/file-metrics-collector/rockcraft.yaml
+++ b/file-metrics-collector/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.17.0/cmd/metricscollector/v1beta1/file-metricscollector/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/metricscollector/v1beta1/file-metricscollector/Dockerfile
 name: file-metrics-collector
 summary: Metrics collector for file info for Katib.
 description: |
   Collects metrics from specified file.
-version: v0.17.0
+version: v0.18.0-rc.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -22,7 +22,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: v0.17.0
+    source-tag: v0.18.0-rc.0
     build-snaps:
       - go
     stage-packages:

--- a/file-metrics-collector/tox.ini
+++ b/file-metrics-collector/tox.ini
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-	rockcraft
+    rockcraft
     yq
 commands =
     # export rock to docker

--- a/file-metrics-collector/tox.ini
+++ b/file-metrics-collector/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist = True
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+	rockcraft
     yq
 commands =
     # export rock to docker
@@ -31,7 +31,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
The changes are based on the [upstream Dockerfile](https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/metricscollector/v1beta1/file-metricscollector/Dockerfile)