### PR TITLE
chore: Update tfevent-metrics-collector rock to 0.18.0-rc.0

### DIFF
--- a/tfevent-metrics-collector/rockcraft.yaml
+++ b/tfevent-metrics-collector/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.17.0/cmd/metricscollector/v1beta1/tfevent-metricscollector/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/metricscollector/v1beta1/tfevent-metricscollector/Dockerfile
 name: tfevent-metrics-collector
 base: ubuntu@22.04
-version: 'v0.17.0'
+version: 'v0.18.0-rc.0'
 summary: Metrics collector for TF Events for Katib.
 description: |
     Collects metrics and stores them on the persistent layer (katib-db-manager). Used as sidecar.
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.17.0"
+      source-tag: "v0.18.0-rc.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/metricscollector/v1beta1/tfevent-metricscollector
@@ -43,7 +43,7 @@ parts:
     tfevent-metrics-collector:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.17.0"
+      source-tag: "v0.18.0-rc.0"
       source-depth: 1
       source-type: git
       organize:

--- a/tfevent-metrics-collector/tox.ini
+++ b/tfevent-metrics-collector/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist = True
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # export rock to docker
@@ -31,7 +31,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
The rock is based on this [upstream Dockerfile](https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/metricscollector/v1beta1/tfevent-metricscollector/Dockerfile)