### PR TITLE
chore: upgrade rocks from 0.18.0-rc to 0.18.0

### DIFF
--- a/earlystopping-medianstop/rockcraft.yaml
+++ b/earlystopping-medianstop/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/earlystopping/medianstop/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/earlystopping/medianstop/v1beta1/Dockerfile
 name: earlystopping-medianstop
 base: ubuntu@22.04
-version: 'v0.18.0-rc.0'
+version: 'v0.18.0'
 summary: Early stopping algorithm for katib.
 description: |
     The median stopping rule stops a pending trial X at step S if the trial’s best 
@@ -26,7 +26,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/earlystopping/medianstop/v1beta1
@@ -45,7 +45,7 @@ parts:
     earlystopping-medianstop:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       organize:

--- a/katib-controller/rockcraft.yaml
+++ b/katib-controller/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/katib-controller/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/katib-controller/v1beta1/Dockerfile
 name: katib-controller
 summary: Katib AutoML Controller
 description: |
@@ -8,7 +8,7 @@ description: |
 
   Katib can perform training jobs using any Kubernetes Custom Resources with out of the box support for Kubeflow Training Operator, Argo Workflows, Tekton Pipelines and many more.
 
-version: v0.18.0-rc.0
+version: v0.18.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -26,7 +26,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: v0.18.0-rc.0
+    source-tag: v0.18.0
     source-subdir: cmd/katib-controller/v1beta1
     build-snaps:
       - go

--- a/katib-db-manager/rockcraft.yaml
+++ b/katib-db-manager/rockcraft.yaml
@@ -1,9 +1,9 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/db-manager/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/db-manager/v1beta1/Dockerfile
 name: katib-db-manager
 summary: Katib DB Controller
 description: |
   Katib database manager.
-version: v0.18.0-rc.0
+version: v0.18.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -22,7 +22,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: v0.18.0-rc.0
+    source-tag: v0.18.0
     build-snaps:
       - go
     stage-packages:

--- a/katib-ui-rock/rockcraft.yaml
+++ b/katib-ui-rock/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/ui/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/ui/v1beta1/Dockerfile
 name: katib-ui
 summary: Katib UI
 description: |
@@ -23,7 +23,7 @@ parts:
     source: https://github.com/kubeflow/kubeflow
     source-type: git
     # Set source-commit here to the commit cited in 
-    # https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/pkg/ui/v1beta1/frontend/COMMIT
+    # https://github.com/kubeflow/katib/blob/v0.18.0/pkg/ui/v1beta1/frontend/COMMIT
     # for this Katib release
     source-commit: 78969ee8246a6f11295378fc61273b1f2dbe07a8
     build-environment:
@@ -58,7 +58,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: v0.18.0-rc.0
+    source-tag: v0.18.0
     source-depth: 1
     build-snaps:
       - node/16/stable
@@ -89,9 +89,9 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: v0.18.0-rc.0
+    source-tag: v0.18.0
     build-snaps:
-      # According to https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/CONTRIBUTING.md
+      # According to https://github.com/kubeflow/katib/blob/v0.18.0/CONTRIBUTING.md
       # the version of go to use is 1.22 or later. As of now, the golang:alpine latest tag
       # uses go v1.24, which is the base for the backend.
       - go/1.24/stable

--- a/suggestion-enas/rockcraft.yaml
+++ b/suggestion-enas/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/nas/enas/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/suggestion/nas/enas/v1beta1/Dockerfile
 name: suggestion-enas
 base: ubuntu@22.04
-version: 'v0.18.0-rc.0'
+version: 'v0.18.0'
 summary: "Katib Suggestion enas"
 description: |
     
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/nas/enas/v1beta1
@@ -42,7 +42,7 @@ parts:
     suggestion-enas:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       organize:

--- a/suggestion-goptuna/rockcraft.yaml
+++ b/suggestion-goptuna/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/goptuna/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/suggestion/goptuna/v1beta1/Dockerfile
 name: suggestion-goptuna
 summary: Decentralized hyperparameter optimization framework, inspired by Optuna implemented in pure Go
 description: "Katib suggestion goptuna"
-version: "v0.18.0-rc.0"
+version: "v0.18.0"
 license: Apache-2.0
 base: ubuntu@22.04
 build-base: ubuntu@22.04
@@ -22,7 +22,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/katib
     source-type: git
-    source-tag: "v0.18.0-rc.0"
+    source-tag: "v0.18.0"
     build-snaps:
       - go/1.21/stable
     override-build: |

--- a/suggestion-hyperband/rockcraft.yaml
+++ b/suggestion-hyperband/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/hyperband/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/suggestion/hyperband/v1beta1/Dockerfile
 name: suggestion-hyperband
 base: ubuntu@22.04
-version: 'v0.18.0-rc.0'
+version: 'v0.18.0'
 summary: "Katib Suggestion Hyperband"
 description: |
     Katib suggestion Hyperband. Hyperband focuses on early stopping as a strategy for optimizing resource allocation.
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/hyperband/v1beta1
@@ -43,7 +43,7 @@ parts:
     suggestion-hyperband:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       organize:

--- a/suggestion-hyperopt/rockcraft.yaml
+++ b/suggestion-hyperopt/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/hyperopt/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/suggestion/hyperopt/v1beta1/Dockerfile
 name: suggestion-hyperopt
 base: ubuntu@22.04
-version: 'v0.18.0-rc.0'
+version: 'v0.18.0'
 summary: "Katib Suggestion Hyperopt"
 description: |
     Ktibe Suggetion Hyperopt. Hyperopt is a Python library for serial and parallel optimization over awkward search spaces, which may include real-valued, discrete, and conditional dimensions.
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/hyperopt/v1beta1
@@ -43,7 +43,7 @@ parts:
     suggestion-hyperopt:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       organize:

--- a/suggestion-nas-darts/rockcraft.yaml
+++ b/suggestion-nas-darts/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/nas/darts/v1beta1
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/suggestion/nas/darts/v1beta1
 name: suggestion-nas-darts
 base: ubuntu@22.04
-version: 'v0.18.0-rc.0'
+version: 'v0.18.0'
 summary: "Katib Suggestion NAS DARTS"
 description: |
       Katib Differentiable Architecture Search implementation.
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/nas/darts/v1beta1
@@ -48,7 +48,7 @@ parts:
     suggestion-nas-darts:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       organize:

--- a/suggestion-optuna/rockcraft.yaml
+++ b/suggestion-optuna/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/optuna/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/suggestion/optuna/v1beta1/Dockerfile
 name: suggestion-optuna
 base: ubuntu@22.04
-version: 'v0.18.0-rc.0'
+version: 'v0.18.0'
 summary: "Katib Suggestion Optuna"
 description: |
       Katib Suggestion Optuna. Optuna is an automatic hyperparameter optimization software framework, particularly designed for machine learning.
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/optuna/v1beta1
@@ -43,7 +43,7 @@ parts:
     suggestion-optuna:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       organize:

--- a/suggestion-pbt/rockcraft.yaml
+++ b/suggestion-pbt/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/pbt/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/suggestion/pbt/v1beta1/Dockerfile
 name: suggestion-pbt
 base: ubuntu@22.04
-version: 'v0.18.0-rc.0'
+version: 'v0.18.0'
 summary: "Katib Suggestion PBT"
 description: |
       Katib Suggestion PBT. Population Based Training, a simple asynchronous optimisation algorithm which effectively utilises a fixed computational budget to jointly optimise a population of models and their hyperparameters to maximise performance.
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/pbt/v1beta1
@@ -48,7 +48,7 @@ parts:
     suggestion-pbt:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       organize:

--- a/suggestion-skopt/rockcraft.yaml
+++ b/suggestion-skopt/rockcraft.yaml
@@ -1,7 +1,7 @@
-# Based on https://github.com/kubeflow/katib/blob/v0.18.0-rc.0/cmd/suggestion/skopt/v1beta1/Dockerfile
+# Based on https://github.com/kubeflow/katib/blob/v0.18.0/cmd/suggestion/skopt/v1beta1/Dockerfile
 name: suggestion-skopt
 base: ubuntu@22.04
-version: 'v0.18.0-rc.0'
+version: 'v0.18.0'
 summary: "Katib Suggestion skopt"
 description: |
       Katib Suggestion skopt. Scikit-Optimize, or skopt, is a simple and efficient library to minimize expensive and noisy black-box functions. It implements several methods for sequential model-based optimization.
@@ -24,7 +24,7 @@ parts:
     requirements-and-deps:
       plugin: python
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       source-subdir: cmd/suggestion/skopt/v1beta1
@@ -48,7 +48,7 @@ parts:
     suggestion-skopt:
       plugin: dump
       source: https://github.com/kubeflow/katib.git
-      source-tag: "v0.18.0-rc.0"
+      source-tag: "v0.18.0"
       source-depth: 1
       source-type: git
       organize:


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7151
No changes in the images, just updated the version. See the [diff](https://github.com/kubeflow/katib/compare/v0.18.0-rc.0...v0.18.0) for reference.