### PR TITLE
feat: `katib-controller` create rocks-automation-ci.yaml

### DIFF
--- a/.github/workflows/on_workflow_dispatch.yaml
+++ b/.github/workflows/on_workflow_dispatch.yaml
@@ -12,12 +12,12 @@ on:
         required: true
         type: string
       dry-run:
-        description: "Dry run?"
+        description: "Dry run? defaults to true"
         required: false
         type: boolean
         default: true
       full-image-tag:
-        description: "Full image reference from Docker registry"
+        description: "Full image reference from Image registry"
         required: true
         type: string
 

--- a/.github/workflows/on_workflow_dispatch.yaml
+++ b/.github/workflows/on_workflow_dispatch.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   run-shared-integration:
-    uses: misohu/charmed-kubeflow-workflows/.github/workflows/integrate-rock.yaml@main
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/integrate-rock.yaml@main
     with:
       rock-dir: ${{ inputs.rock-dir }}
       full-image-tag: ${{ inputs.full-image-tag }}

--- a/.github/workflows/on_workflow_dispatch.yaml
+++ b/.github/workflows/on_workflow_dispatch.yaml
@@ -1,0 +1,31 @@
+name: Manually Run Rock Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      rock-dir:
+        description: "Path to the rock directory (e.g. rocks/my-rock)"
+        required: true
+        type: string
+      target-branch:
+        description: "Branch to integrate into"
+        required: true
+        type: string
+      dry-run:
+        description: "Dry run?"
+        required: false
+        type: boolean
+        default: true
+      full-image-tag:
+        description: "Full image reference from Docker registry"
+        required: true
+        type: string
+
+jobs:
+  run-shared-integration:
+    uses: misohu/charmed-kubeflow-workflows/.github/workflows/integrate-rock.yaml@main
+    with:
+      rock-dir: ${{ inputs.rock-dir }}
+      full-image-tag: ${{ inputs.full-image-tag }}
+      event-name: workflow_dispatch
+    secrets: inherit

--- a/katib-controller/rock-ci-metadata.yaml
+++ b/katib-controller/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/katib-operators.git
+   
+    replace-image:
+      - file: charms/katib-controller/metadata.yaml
+        path: resources.oci-image.upstream-source


### PR DESCRIPTION
Closes: https://github.com/canonical/katib-rocks/issues/87

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
- add `workflow_dispatch` job for manual rock integration.

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.